### PR TITLE
Add option to compare against provided reference database and bugfixes for metaQUAST

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,6 +29,7 @@ min_completeness: 50
 max_contamination: 10
 # Quality evaluation
 quality_evaluation: ['checkm', 'busco', 'gunc']
+reference_database: ""  # path to FastA file with reference sequences
 # Taxonomic profiling
 taxonomic_profiling: true
 taxprofilers: ['phylophlan3', 'gtdbtk', 'kraken2']

--- a/workflow/rules/quality_summary.smk
+++ b/workflow/rules/quality_summary.smk
@@ -43,12 +43,14 @@ rule metaQUAST:
         cores = 8,
         metaquast = 1
     params:
-        outdir = "{resultdir}/stats//metaquast/{sample}-{assembler}"
+        outdir = "{resultdir}/stats//metaquast/{sample}-{assembler}",
+        reffa = lambda wildcards: f"-r {config['reference_database']}" if config['reference_database'] != "" else "", 
     threads: 8
     shell:
         """
         metaquast.py \
             -o {params.outdir} \
+            {params.reffa} \
             --threads {threads} \
             --ambiguity-usage all \
             --no-icarus \

--- a/workflow/rules/quality_summary.smk
+++ b/workflow/rules/quality_summary.smk
@@ -39,7 +39,7 @@ rule metaQUAST:
     message: "Run metaQUAST on the contigs: {wildcards.sample}"
     conda: "../envs/ENVS_quast.yaml"
     resources:
-        mem = 24,
+        mem = lambda wildcards, attempt: 24 + attempt * 24,
         cores = 8,
         metaquast = 1
     params:


### PR DESCRIPTION
- add option to provide an external database for quality evaluation (closes #12)
- allow multiple attempts with increasing memory requirements when enabling restarting in Snakemake (closes #18)